### PR TITLE
Use curl for downloading the jwks file because of proxy

### DIFF
--- a/src/CognitoClient.php
+++ b/src/CognitoClient.php
@@ -308,7 +308,13 @@ class CognitoClient
             $this->userPoolId
         );
 
-        return file_get_contents($url);
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_URL,$url);
+        $result = curl_exec($ch);
+        curl_close($ch);
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
This PR is solving the issue #27 with file_get_contents if you are behind a proxy and want to get jwks json file per http request.