### PR TITLE
Add missing php on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ curl -sS https://getcomposer.org/installer | php
 Next, run the Composer command to install the latest version:
 
 ```bash
-composer.phar require pmill/aws-cognito
+php composer.phar require pmill/aws-cognito
 ```
 
 Usage


### PR DESCRIPTION
Without use `php composer.phar` can't run