### PR TITLE
Add compatibility with cognito id tokens generated by hosted UI

### DIFF
--- a/src/CognitoClient.php
+++ b/src/CognitoClient.php
@@ -494,7 +494,7 @@ class CognitoClient
             throw new TokenVerificationException('invalid iss');
         }
 
-        if ($jwtPayload['token_use'] !== 'access') {
+        if ( !in_array($jwtPayload['token_use'], ['id','access']) ) {
             throw new TokenVerificationException('invalid token_use');
         }
 
@@ -502,7 +502,7 @@ class CognitoClient
             throw new TokenExpiryException('invalid exp');
         }
 
-        return $jwtPayload['username'];
+        return $jwtPayload['username'] ?? $jwtPayload['cognito:username'];
     }
 
     /**


### PR DESCRIPTION
Hi @pmill, thanks for the great package!

On my project, I also need support authorization by tokens generated with Cognito Hosted UI. But they have a little bit different fields. 

Here is an example of the payload:
{
  "at_hash": "",
  "sub": "",
  "aud": "",
  "event_id": "",
  **"token_use": "id",**
  "auth_time": 1573809477,
  "iss": "",
  "name": "SomeName",
  **"cognito:username": "UserName",**
  "exp": 1573813077,
  "iat": 1573809477,
  "email": "test@test.com"
}

