### PR TITLE
update auth flow name and add three methods: adminCreateUser, adminSetUserPassword, adminResetUserPassword

### DIFF
--- a/src/CognitoClient.php
+++ b/src/CognitoClient.php
@@ -72,7 +72,7 @@ class CognitoClient
     {
         try {
             $response = $this->client->adminInitiateAuth([
-                'AuthFlow' => 'ADMIN_NO_SRP_AUTH',
+                'AuthFlow' => 'ADMIN_USER_PASSWORD_AUTH',
                 'AuthParameters' => [
                     'USERNAME' => $username,
                     'PASSWORD' => $password,

--- a/src/CognitoClient.php
+++ b/src/CognitoClient.php
@@ -89,6 +89,27 @@ class CognitoClient
     }
 
     /**
+     * @param string $username
+     * @param string $password
+     * @param bool $isPermanent
+     *
+     * @throws Exception
+     */
+    public function adminSetUserPassword(string $username, string $password, bool $isPermanent = true)
+    {
+        try {
+            $this->client->adminSetUserPassword([
+                'Password' => $password,
+                'Permanent' => $isPermanent,
+                'UserPoolId' => $this->userPoolId,
+                'Username' => $username,
+            ]);
+        } catch (CognitoIdentityProviderException $e) {
+            throw CognitoResponseException::createFromCognitoException($e);
+        }
+    }
+
+    /**
      * @param string $challengeName
      * @param array $challengeResponses
      * @param string $session
@@ -370,6 +391,50 @@ class CognitoClient
             ]);
 
             return $response['UserSub'];
+        } catch (CognitoIdentityProviderException $e) {
+            throw CognitoResponseException::createFromCognitoException($e);
+        }
+    }
+
+    /**
+     * @param string $username
+     * @param array $attributes
+     * @param array $parameters
+     *
+     * @return array User
+     * @throws Exception
+     */
+    public function adminCreateUser(string $username, array $attributes = [], array $parameters = [])
+    {
+        $userAttributes = $this->buildAttributesArray($attributes);
+        $createParameters = [
+            'UserAttributes' => $userAttributes,
+            'UserPoolId' => $this->userPoolId,
+            'Username' => $username
+        ];
+
+        $createUserParameters = array_merge($createParameters, $parameters);
+
+        try {
+            $response = $this->client->adminCreateUser($createUserParameters);
+            return $response['User'];
+        } catch (CognitoIdentityProviderException $e) {
+            throw CognitoResponseException::createFromCognitoException($e);
+        }
+    }
+
+    /**
+     * @param string $username
+     *
+     * @throws Exception
+     */
+    public function adminResetUserPassword(string $username)
+    {
+        try {
+            $this->client->adminResetUserPassword([
+                'UserPoolId' => $this->userPoolId,
+                'Username' => $username
+            ]);
         } catch (CognitoIdentityProviderException $e) {
             throw CognitoResponseException::createFromCognitoException($e);
         }


### PR DESCRIPTION
1. Update authentication auth flow name from ADMIN_NO_SRP_AUTH to ADMIN_USER_PASSWORD_AUTH (https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html)
2. Add three CognitoIdentityProvider methods: adminCreateUser, adminSetUserPassword, adminResetUserPassword.